### PR TITLE
feat(feed): フィード一覧のフィルタ追加＋カードUI拡充

### DIFF
--- a/src/app/feed/FeedListClient.tsx
+++ b/src/app/feed/FeedListClient.tsx
@@ -137,7 +137,15 @@ export function FeedListClient({ feeds }: { feeds: Feed[] }) {
                     }`}
                     aria-label={`${f.title} を後で読むに${isLater ? "解除" : "追加"}`}
                   >
-                    {isLater ? "saved" : "read later"}
+                    <svg
+                      aria-hidden="true"
+                      viewBox="0 0 24 24"
+                      className="h-4 w-4"
+                      fill="currentColor"
+                    >
+                      <path d="M6 2h12a2 2 0 0 1 2 2v18l-8-4-8 4V4a2 2 0 0 1 2-2z" />
+                    </svg>
+                    <span className="sr-only">{isLater ? "saved" : "read later"}</span>
                   </button>
                   <button
                     type="button"
@@ -150,7 +158,19 @@ export function FeedListClient({ feeds }: { feeds: Feed[] }) {
                     }`}
                     aria-label={`${f.title} を${isRead ? "未読に戻す" : "既読にする"}`}
                   >
-                    {isRead ? "read" : "mark read"}
+                    <svg
+                      aria-hidden="true"
+                      viewBox="0 0 24 24"
+                      className="h-4 w-4"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <polyline points="20 6 9 17 4 12" />
+                    </svg>
+                    <span className="sr-only">{isRead ? "read" : "mark read"}</span>
                   </button>
                 </div>
               </div>

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -18,14 +18,70 @@ type Feed = {
 };
 
 const feeds: Feed[] = [
-  { id: "1", title: "Next.js Blog", description: "Next.js の公式ブログ。リリース情報やベストプラクティスを配信。", siteUrl: "https://nextjs.org/blog", latestArticleUrl: "https://nextjs.org/blog/next-15", updatedAt: "2024-09-15T09:00:00.000Z" },
-  { id: "2", title: "Vercel Changelog", description: "Vercel の変更履歴。新機能や改善点のまとめ。", siteUrl: "https://vercel.com/changelog", latestArticleUrl: "https://vercel.com/changelog/vercel-september-updates", updatedAt: "2024-10-01T12:00:00.000Z" },
-  { id: "3", title: "MDN Web Docs", description: "Web 標準とブラウザ実装の最新情報。", siteUrl: "https://developer.mozilla.org/", latestArticleUrl: "https://developer.mozilla.org/en-US/blog/", updatedAt: "2024-08-20T00:00:00.000Z" },
-  { id: "4", title: "TypeScript Blog", description: "TypeScript の公式ブログ", siteUrl: "https://devblogs.microsoft.com/typescript/", latestArticleUrl: "https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/", updatedAt: "2024-10-05T00:00:00.000Z" },
-  { id: "5", title: "React Blog", description: "React のブログ", siteUrl: "https://react.dev/blog", latestArticleUrl: "https://react.dev/blog/2024/08/01/react-19", updatedAt: "2024-08-01T00:00:00.000Z" },
-  { id: "6", title: "WebKit Blog", description: "WebKit の更新情報", siteUrl: "https://webkit.org/blog/", latestArticleUrl: "https://webkit.org/blog/15000/webkit-updates/", updatedAt: "2024-09-10T00:00:00.000Z" },
-  { id: "7", title: "Chromium Blog", description: "Chrome/Chromium の開発ブログ", siteUrl: "https://blog.chromium.org/", latestArticleUrl: "https://blog.chromium.org/2024/09/chrome-updates.html", updatedAt: "2024-09-20T00:00:00.000Z" },
-  { id: "8", title: "Node.js Blog", description: "Node.js リリース情報", siteUrl: "https://nodejs.org/en/blog", latestArticleUrl: "https://nodejs.org/en/blog/release/v22.9.0", updatedAt: "2024-09-25T00:00:00.000Z" }
+  {
+    id: "1",
+    title: "Next.js Blog",
+    description: "Next.js の公式ブログ。リリース情報やベストプラクティスを配信。",
+    siteUrl: "https://nextjs.org/blog",
+    latestArticleUrl: "https://nextjs.org/blog/next-15",
+    updatedAt: "2024-09-15T09:00:00.000Z",
+  },
+  {
+    id: "2",
+    title: "Vercel Changelog",
+    description: "Vercel の変更履歴。新機能や改善点のまとめ。",
+    siteUrl: "https://vercel.com/changelog",
+    latestArticleUrl: "https://vercel.com/changelog/vercel-september-updates",
+    updatedAt: "2024-10-01T12:00:00.000Z",
+  },
+  {
+    id: "3",
+    title: "MDN Web Docs",
+    description: "Web 標準とブラウザ実装の最新情報。",
+    siteUrl: "https://developer.mozilla.org/",
+    latestArticleUrl: "https://developer.mozilla.org/en-US/blog/",
+    updatedAt: "2024-08-20T00:00:00.000Z",
+  },
+  {
+    id: "4",
+    title: "TypeScript Blog",
+    description: "TypeScript の公式ブログ",
+    siteUrl: "https://devblogs.microsoft.com/typescript/",
+    latestArticleUrl: "https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/",
+    updatedAt: "2024-10-05T00:00:00.000Z",
+  },
+  {
+    id: "5",
+    title: "React Blog",
+    description: "React のブログ",
+    siteUrl: "https://react.dev/blog",
+    latestArticleUrl: "https://react.dev/blog/2024/08/01/react-19",
+    updatedAt: "2024-08-01T00:00:00.000Z",
+  },
+  {
+    id: "6",
+    title: "WebKit Blog",
+    description: "WebKit の更新情報",
+    siteUrl: "https://webkit.org/blog/",
+    latestArticleUrl: "https://webkit.org/blog/15000/webkit-updates/",
+    updatedAt: "2024-09-10T00:00:00.000Z",
+  },
+  {
+    id: "7",
+    title: "Chromium Blog",
+    description: "Chrome/Chromium の開発ブログ",
+    siteUrl: "https://blog.chromium.org/",
+    latestArticleUrl: "https://blog.chromium.org/2024/09/chrome-updates.html",
+    updatedAt: "2024-09-20T00:00:00.000Z",
+  },
+  {
+    id: "8",
+    title: "Node.js Blog",
+    description: "Node.js リリース情報",
+    siteUrl: "https://nodejs.org/en/blog",
+    latestArticleUrl: "https://nodejs.org/en/blog/release/v22.9.0",
+    updatedAt: "2024-09-25T00:00:00.000Z",
+  },
 ];
 
 export default function FeedPage() {


### PR DESCRIPTION
目的
- フィード一覧(/feed)にサイト単位のフィルタリング機能を追加する
- カードUIを増やし（3件→複数件）、各カードに「read later」「read」ボタンを追加する

スコープ
- /feed 画面のUI改善（クライアントコンポーネント導入によるフィルタ）
- 仮データの拡充（複数サイト・複数件）
- ボタンはUIのみ（動作はダミー/後続Issue）

非スコープ
- 既読管理や後で読むの永続化（Server Actions/DB 連携）

受け入れ条件
- /feed にサイトフィルタ（セレクト等）が表示され、選択で一覧が絞り込まれる
- カードに「read later」「read」ボタンが表示される（クリックでダミー動作）
- ビルド/型チェック/ESLint が通る

Closes #5 